### PR TITLE
Run containers in the detached mode

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo docker-compose -f docker/docker-compose.yml up
+sudo docker-compose -f docker/docker-compose.yml up -d


### PR DESCRIPTION
Since I was using this repo all day, I was avoiding using the `run.sh` because I would loose that terminal to running docker compose. Instead I was using `docker-compose -f docker/docker-compose.yml up -d`. It's such a small change But I think is more convenient to use.